### PR TITLE
Make MaterialProperty references const

### DIFF
--- a/include/auxkernels/PyrolysisGasVelocity.h
+++ b/include/auxkernels/PyrolysisGasVelocity.h
@@ -17,7 +17,7 @@ public:
 protected:
   virtual Real computeValue();
   int _component;
-  MaterialProperty<PropertyPack> & _property;
+  const MaterialProperty<PropertyPack> & _property;
 };
 
 

--- a/include/auxkernels/PyrolysisRate.h
+++ b/include/auxkernels/PyrolysisRate.h
@@ -16,7 +16,7 @@ public:
 
 protected:
   virtual Real computeValue();
-  MaterialProperty<PropertyPack> & _property;
+  const MaterialProperty<PropertyPack> & _property;
 };
 
 

--- a/include/bcs/HeatRadiationBC.h
+++ b/include/bcs/HeatRadiationBC.h
@@ -19,8 +19,8 @@ protected:
 //  void interpolate(std::vector<Real> &qc, std::vector<Real>  &ts, std::vector<Point> &pts, Real t);
 //  void readFile();
 
-  MaterialProperty<Real> & _flux;
-  MaterialProperty<Real> & _flux_jacobi;
+  const MaterialProperty<Real> & _flux;
+  const MaterialProperty<Real> & _flux_jacobi;
 };
 
 template<>

--- a/include/kernels/DarcyPressure.h
+++ b/include/kernels/DarcyPressure.h
@@ -15,7 +15,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
 private:
-  MaterialProperty<PropertyPack> & _property;
+  const MaterialProperty<PropertyPack> & _property;
 
 };
 

--- a/include/kernels/DensitySourceKernel.h
+++ b/include/kernels/DensitySourceKernel.h
@@ -14,7 +14,7 @@ protected:
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
 private:
-   MaterialProperty<PropertyPack> & _property;
+  const MaterialProperty<PropertyPack> & _property;
 
 };
 

--- a/include/kernels/GasConvection.h
+++ b/include/kernels/GasConvection.h
@@ -13,7 +13,7 @@ protected:
   virtual Real computeQpJacobian();
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 private:
-  MaterialProperty<PropertyPack> & _property;
+  const MaterialProperty<PropertyPack> & _property;
 };
 
 template<>

--- a/include/kernels/HeatConductionKernel.h
+++ b/include/kernels/HeatConductionKernel.h
@@ -15,7 +15,7 @@ protected:
   virtual Real computeQpJacobian();
 
 private:
-  MaterialProperty<PropertyPack> & _property;
+  const MaterialProperty<PropertyPack> & _property;
 };
 
 template<>

--- a/include/kernels/PyrolysisSourceKernel.h
+++ b/include/kernels/PyrolysisSourceKernel.h
@@ -14,7 +14,7 @@ protected:
   virtual Real computeQpJacobian();
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 private:
-  MaterialProperty<PropertyPack> & _property;
+  const MaterialProperty<PropertyPack> & _property;
 
 };
 

--- a/include/kernels/TemperatureTimeDerivative.h
+++ b/include/kernels/TemperatureTimeDerivative.h
@@ -15,7 +15,7 @@ protected:
   virtual Real computeQpJacobian();
 
 private:
-  MaterialProperty<PropertyPack> & _Property;;
+  const MaterialProperty<PropertyPack> & _Property;;
 };
 
 template<>


### PR DESCRIPTION
Prepare for upcoming MOOSE change: https://github.com/idaholab/moose/pull/5224
This works with the current MOOSE. 
